### PR TITLE
Fix link error

### DIFF
--- a/MWPhotoBrowser.xcodeproj/project.pbxproj
+++ b/MWPhotoBrowser.xcodeproj/project.pbxproj
@@ -314,7 +314,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -385,7 +385,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.MWPhotoBrowser;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				"VALID_ARCHS[sdk=*]" = "arm64 armv7 armv7s";
 			};
 			name = Debug;
 		};
@@ -407,8 +406,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.MWPhotoBrowser;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				VALID_ARCHS = "arm64 armv7 armv7s";
-				"VALID_ARCHS[sdk=*]" = "arm64 armv7 armv7s";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
The 'build active architecture only' settings of dependency projects are YES in debug, so they are only built for one architecture. If the 'build active architecture only' setting of MWPhotoBrowser is NO, MWPhotoBrowser will be built for multiple architecture (e.g. i386 and x86_64 when build on simulator), then Xcode is unable to find a valid built framework for the dependency projects.
